### PR TITLE
fix: add a DEFAULT_COLOR which avoid the 'initial crash' when using COLORFUL: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,13 +176,13 @@ WebGLFluid(document.querySelector('canvas'), {
 
 ## Default dye color (DEFAULT_COLOR)
 
-DEFAULT_COLOR is the RGB used for **pointer** splats (hover). The library’s own default is `{ r: 0.01, g: 0.01, b: 0.01 }`. It is only applied when you do **not** pass DEFAULT_COLOR in your options.
+DEFAULT_COLOR is the RGB used for **pointer** splats (hover). The library’s own default is `{ r: 0.09, g: 0.12, b: 0.15 }`. It is only applied when you do **not** pass DEFAULT_COLOR in your options.
 
 **Omit `DEFAULT_COLOR`** pointer splats use the built-in default above, and **each mouse/touch down** picks a **new random** dye color (`generateColor()`).
 
 ```ts
 WebGLFluid(document.querySelector('canvas'), {
-  DEFAULT_COLOR: { r: 0.09, g: 0.12, b: 0.15 },
+  DEFAULT_COLOR: { r: 0.09, g: 0, b: 0 },
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ WebGLFluid(document.querySelector('canvas'), {
   COLOR_UPDATE_SPEED: 10,
   PAUSED: false,
   BACK_COLOR: { r: 0, g: 0, b: 0 },
+  DEFAULT_COLOR: { r: 0.01, g: 0.01, b: 0.01 },
   TRANSPARENT: false,
   BLOOM: true,
   BLOOM_ITERATIONS: 8,
@@ -168,6 +169,29 @@ WebGLFluid(document.querySelector('canvas'), {
 ```ts
 WebGLFluid(document.querySelector('canvas'), {
   SPLAT_COUNT: Number.parseInt(Math.random() * 20) + 5,
+})
+```
+
+<br>
+
+## Default dye color (DEFAULT_COLOR)
+
+DEFAULT_COLOR is the RGB used for **pointer** splats (hover). The library’s own default is `{ r: 0.01, g: 0.01, b: 0.01 }`. It is only applied when you do **not** pass DEFAULT_COLOR in your options.
+
+**Omit `DEFAULT_COLOR`** pointer splats use the built-in default above, and **each mouse/touch down** picks a **new random** dye color (`generateColor()`).
+
+```ts
+WebGLFluid(document.querySelector('canvas'), {
+  DEFAULT_COLOR: { r: 0.09, g: 0.12, b: 0.15 },
+})
+```
+
+Stable single color for hover and click (pair with `COLORFUL: false` if you do not want the palette to drift over time):
+
+```ts
+WebGLFluid(document.querySelector('canvas'), {
+  COLORFUL: false,
+  DEFAULT_COLOR: { r: 0.1, g: 0.05, b: 0.2 },
 })
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,6 @@ export default function (el, config) {
     COLOR_UPDATE_SPEED: 10,
     PAUSED: false,
     BACK_COLOR: { r: 0, g: 0, b: 0 },
-    DEFAULT_COLOR: { r: 0.01, g: 0.01, b: 0.01 },
     TRANSPARENT: false,
     BLOOM: true,
     BLOOM_ITERATIONS: 8,
@@ -75,7 +74,7 @@ export default function (el, config) {
     this.deltaY = 0
     this.down = false
     this.moved = false
-    this.color = config.DEFAULT_COLOR
+    this.color = config.DEFAULT_COLOR || { r: 0.09, g: 0.12, b: 0.15 }
   }
 
   const pointers = []

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ export default function (el, config) {
     COLOR_UPDATE_SPEED: 10,
     PAUSED: false,
     BACK_COLOR: { r: 0, g: 0, b: 0 },
+    DEFAULT_COLOR: { r: 0.01, g: 0.01, b: 0.01 },
     TRANSPARENT: false,
     BLOOM: true,
     BLOOM_ITERATIONS: 8,
@@ -74,7 +75,7 @@ export default function (el, config) {
     this.deltaY = 0
     this.down = false
     this.moved = false
-    this.color = { r: 0.09, g: 0.12, b: 0.15 }
+    this.color = config.DEFAULT_COLOR
   }
 
   const pointers = []
@@ -1530,7 +1531,9 @@ export default function (el, config) {
     pointer.prevTexcoordY = pointer.texcoordY
     pointer.deltaX = 0
     pointer.deltaY = 0
-    pointer.color = generateColor()
+    if (!config.DEFAULT_COLOR) {
+      pointer.color = generateColor()
+    }
   }
 
   function updatePointerMoveData(pointer, posX, posY) {

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ export default function (el, config) {
     this.deltaY = 0
     this.down = false
     this.moved = false
-    this.color = [30, 0, 300]
+    this.color = { r: 0.09, g: 0.12, b: 0.15 }
   }
 
   const pointers = []


### PR DESCRIPTION
### Description
This PR contains 2 related changes:

**1. The addition of a `DEFAULT_COLOR` option.**

This allows the user to set their own color when the `COLORFUL` option is `false`.

**2. The fix of the crash described in the issue.**

By introducing the `DEFAULT_COLOR` option, the initial color is now set using a compatible format, preventing the crash that occurred when the user moved the cursor before clicking on the canvas.

### Linked Issues
fix #10